### PR TITLE
Add public API for hours data and open/closed status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[isthefeldopen.com](https://isthefeldopen.com)** is a single-page website that answers one question: _Is Tempelhof Feld in Berlin currently open?_
 
-It takes the visitor's current time, compares it against a hardcoded table of monthly opening and closing times, and displays open or closed status with a countdown timer.
+It takes the visitor's current time, compares it against monthly opening and closing times, and displays open or closed status with a countdown timer. It also exposes a public API for other tools and integrations to consume the hours data.
 
 ## Tech Stack
 
@@ -23,28 +23,66 @@ No React, Vue, Svelte, or any JS framework. No Tailwind or any CSS framework —
 - Accessibility and WCAG contrast standards must be maintained throughout
 - CSS custom properties (variables) should be used for theming, especially for the open/closed colour schemes
 
-## Hours Data Structure
+## API
 
-Monthly opening and closing times are stored as a JavaScript object directly in the Astro template:
+The site exposes a public JSON API. CORS is enabled for all origins.
 
-```js
-const hours = {
-  january: { open: "06:00", close: "20:00" },
-  february: { open: "06:00", close: "20:30" },
-  march: { open: "06:00", close: "21:00" },
-  april: { open: "06:00", close: "21:30" },
-  may: { open: "06:00", close: "22:00" },
-  june: { open: "06:00", close: "22:30" },
-  july: { open: "06:00", close: "22:30" },
-  august: { open: "06:00", close: "22:00" },
-  september: { open: "06:00", close: "21:30" },
-  october: { open: "06:00", close: "20:30" },
-  november: { open: "06:00", close: "20:00" },
-  december: { open: "06:00", close: "20:00" },
-};
+### `GET /api/hours`
+
+Returns the full 12-month hours table:
+
+```json
+{
+  "hours": {
+    "january": { "open": "07:30", "close": "17:00" },
+    "february": { "open": "07:00", "close": "18:00" },
+    "may": {
+      "open": "06:00",
+      "close": "21:30",
+      "late_close": "22:00",
+      "split_day": 16
+    }
+  }
+}
 ```
 
-> **Note:** A future enhancement may replace this with an internal API (see [#11](https://github.com/cartogram/openfeld/issues/11)).
+Some months include `late_close` and `split_day` fields when closing times change partway through the month.
+
+### `POST /api/status`
+
+Accepts a timestamp and returns whether the field is open or closed at that moment:
+
+**Request:**
+
+```json
+{ "timestamp": "2025-07-15T12:00:00+02:00" }
+```
+
+**Response (open):**
+
+```json
+{
+  "status": "open",
+  "closes_at": "23:00",
+  "time_remaining": "11:00:00"
+}
+```
+
+**Response (closed):**
+
+```json
+{
+  "status": "closed",
+  "opens_at": "06:00",
+  "time_remaining": "02:30:00"
+}
+```
+
+Returns `400` for missing, non-string, or unparseable timestamps.
+
+## Hours Data
+
+Monthly opening and closing times are stored in `src/data/hours.ts` and shared between the frontend UI and the API endpoints.
 
 ## Development
 

--- a/src/components/Interface.astro
+++ b/src/components/Interface.astro
@@ -1,5 +1,4 @@
 ---
-import { HOURS } from "../data/hours";
 import type { Translations } from "../i18n";
 
 interface Props {
@@ -11,7 +10,6 @@ const { t } = Astro.props;
 
 <div
   class="interface"
-  data-hours={JSON.stringify(HOURS)}
   data-t-open={t.open}
   data-t-closed={t.closed}
   data-t-opens-in={t.opensIn}
@@ -24,72 +22,20 @@ const { t } = Astro.props;
 </div>
 
 <script>
+  import {
+    isOpen,
+    getTargetTime as getTarget,
+  } from "../data/hours.js";
+
   const el = document.querySelector(".interface") as HTMLElement;
   const statusEl = el.querySelector(".status") as HTMLElement;
   const countdownLabel = el.querySelector(".countdown-label") as HTMLElement;
   const countdownEl = el.querySelector(".countdown") as HTMLTimeElement;
-  const hours = JSON.parse(el.dataset.hours!);
 
   const tOpen = el.dataset.tOpen!;
   const tClosed = el.dataset.tClosed!;
   const tOpensIn = el.dataset.tOpensIn!;
   const tClosesIn = el.dataset.tClosesIn!;
-
-  function getCloseTime(entry: any, day: number): string {
-    if (entry.splitDay && day >= entry.splitDay && entry.lateClose) {
-      return entry.lateClose;
-    }
-    return entry.close;
-  }
-
-  function timeToMinutes(time: string): number {
-    const [h, m] = time.split(":").map(Number);
-    return h * 60 + m;
-  }
-
-  function getStatus(now: Date) {
-    const entry = hours[now.getMonth()];
-    if (!entry) return false;
-
-    const currentMinutes = now.getHours() * 60 + now.getMinutes();
-    const openMinutes = timeToMinutes(entry.open);
-    const closeMinutes = timeToMinutes(getCloseTime(entry, now.getDate()));
-
-    return currentMinutes >= openMinutes && currentMinutes < closeMinutes;
-  }
-
-  function getTargetTime(now: Date, isOpen: boolean): Date {
-    const entry = hours[now.getMonth()];
-    const target = new Date(now);
-
-    if (isOpen) {
-      const [h, m] = getCloseTime(entry, now.getDate())
-        .split(":")
-        .map(Number);
-      target.setHours(h, m, 0, 0);
-      return target;
-    }
-
-    // Closed: figure out next opening
-    const currentMinutes = now.getHours() * 60 + now.getMinutes();
-    const openMinutes = timeToMinutes(entry.open);
-
-    if (currentMinutes < openMinutes) {
-      // Before opening today
-      const [h, m] = entry.open.split(":").map(Number);
-      target.setHours(h, m, 0, 0);
-      return target;
-    }
-
-    // After closing today — next opening is tomorrow
-    const tomorrow = new Date(now);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    tomorrow.setHours(0, 0, 0, 0);
-    const tomorrowEntry = hours[tomorrow.getMonth()];
-    const [h, m] = tomorrowEntry.open.split(":").map(Number);
-    tomorrow.setHours(h, m, 0, 0);
-    return tomorrow;
-  }
 
   function formatDuration(ms: number): { display: string; iso: string } {
     const totalSeconds = Math.max(0, Math.floor(ms / 1000));
@@ -104,17 +50,17 @@ const { t } = Astro.props;
 
   function update() {
     const now = new Date();
-    const isOpen = getStatus(now);
-    const status = isOpen ? "open" : "closed";
+    const open = isOpen(now);
+    const status = open ? "open" : "closed";
 
     document.documentElement.setAttribute("data-status", status);
-    statusEl.textContent = isOpen ? tOpen : tClosed;
+    statusEl.textContent = open ? tOpen : tClosed;
 
-    const target = getTargetTime(now, isOpen);
+    const { target } = getTarget(now, open);
     const remaining = target.getTime() - now.getTime();
     const { display, iso } = formatDuration(remaining);
 
-    countdownLabel.textContent = isOpen ? tClosesIn : tOpensIn;
+    countdownLabel.textContent = open ? tClosesIn : tOpensIn;
     countdownEl.textContent = display;
     countdownEl.setAttribute("datetime", iso);
   }

--- a/src/data/hours.ts
+++ b/src/data/hours.ts
@@ -37,3 +37,56 @@ export const MONTH_NAMES = [
   "November",
   "December",
 ];
+
+export function getCloseTime(entry: MonthEntry, day: number): string {
+  if (entry.splitDay && day >= entry.splitDay && entry.lateClose) {
+    return entry.lateClose;
+  }
+  return entry.close;
+}
+
+export function timeToMinutes(time: string): number {
+  const [h, m] = time.split(":").map(Number);
+  return h * 60 + m;
+}
+
+export function isOpen(date: Date): boolean {
+  const entry = HOURS[date.getMonth()];
+  const currentMinutes = date.getHours() * 60 + date.getMinutes();
+  const openMinutes = timeToMinutes(entry.open);
+  const closeMinutes = timeToMinutes(getCloseTime(entry, date.getDate()));
+  return currentMinutes >= openMinutes && currentMinutes < closeMinutes;
+}
+
+export function getTargetTime(
+  date: Date,
+  open: boolean,
+): { target: Date; time: string } {
+  const entry = HOURS[date.getMonth()];
+  const target = new Date(date);
+
+  if (open) {
+    const closeTime = getCloseTime(entry, date.getDate());
+    const [h, m] = closeTime.split(":").map(Number);
+    target.setHours(h, m, 0, 0);
+    return { target, time: closeTime };
+  }
+
+  const currentMinutes = date.getHours() * 60 + date.getMinutes();
+  const openMinutes = timeToMinutes(entry.open);
+
+  if (currentMinutes < openMinutes) {
+    const [h, m] = entry.open.split(":").map(Number);
+    target.setHours(h, m, 0, 0);
+    return { target, time: entry.open };
+  }
+
+  // After closing — next opening is tomorrow
+  const tomorrow = new Date(date);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(0, 0, 0, 0);
+  const tomorrowEntry = HOURS[tomorrow.getMonth()];
+  const [h, m] = tomorrowEntry.open.split(":").map(Number);
+  tomorrow.setHours(h, m, 0, 0);
+  return { target: tomorrow, time: tomorrowEntry.open };
+}

--- a/src/data/status.ts
+++ b/src/data/status.ts
@@ -1,0 +1,43 @@
+import { isOpen, getTargetTime } from "./hours.js";
+
+function padTime(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function formatDurationFromMs(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  return `${padTime(h)}:${padTime(m)}:${padTime(s)}`;
+}
+
+export interface StatusResult {
+  status: "open" | "closed";
+  closes_at?: string;
+  opens_at?: string;
+  time_remaining: string;
+}
+
+export function getStatus(date: Date): StatusResult {
+  // Convert to Berlin timezone (Europe/Berlin)
+  const berlinTime = new Date(
+    date.toLocaleString("en-US", { timeZone: "Europe/Berlin" }),
+  );
+  const open = isOpen(berlinTime);
+  const { target, time } = getTargetTime(berlinTime, open);
+
+  if (open) {
+    return {
+      status: "open",
+      closes_at: time,
+      time_remaining: formatDurationFromMs(target.getTime() - date.getTime()),
+    };
+  }
+
+  return {
+    status: "closed",
+    opens_at: time,
+    time_remaining: formatDurationFromMs(target.getTime() - date.getTime()),
+  };
+}

--- a/src/pages/api/hours.ts
+++ b/src/pages/api/hours.ts
@@ -1,0 +1,38 @@
+import type { APIRoute } from "astro";
+import { HOURS, MONTH_NAMES } from "../../data/hours.js";
+
+export const prerender = false;
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+export const OPTIONS: APIRoute = () => {
+  return new Response(null, { status: 204, headers: corsHeaders });
+};
+
+export const GET: APIRoute = () => {
+  const hours: Record<string, { open: string; close: string }> = {};
+
+  for (const [index, entry] of Object.entries(HOURS)) {
+    const name = MONTH_NAMES[Number(index)].toLowerCase();
+    hours[name] = { open: entry.open, close: entry.close };
+    if (entry.lateClose) {
+      (hours[name] as Record<string, string>).late_close = entry.lateClose;
+    }
+    if (entry.splitDay) {
+      (hours[name] as Record<string, string | number>).split_day =
+        entry.splitDay;
+    }
+  }
+
+  return new Response(JSON.stringify({ hours }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      ...corsHeaders,
+    },
+  });
+};

--- a/src/pages/api/status.ts
+++ b/src/pages/api/status.ts
@@ -1,0 +1,68 @@
+import type { APIRoute } from "astro";
+import { getStatus } from "../../data/status.js";
+
+export const prerender = false;
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+export const OPTIONS: APIRoute = () => {
+  return new Response(null, { status: 204, headers: corsHeaders });
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Invalid JSON in request body" }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json", ...corsHeaders },
+      },
+    );
+  }
+
+  if (
+    !body ||
+    typeof body !== "object" ||
+    !("timestamp" in body) ||
+    typeof (body as Record<string, unknown>).timestamp !== "string"
+  ) {
+    return new Response(
+      JSON.stringify({
+        error:
+          "Missing or invalid 'timestamp' field. Expected an ISO 8601 string.",
+      }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json", ...corsHeaders },
+      },
+    );
+  }
+
+  const date = new Date((body as { timestamp: string }).timestamp);
+
+  if (isNaN(date.getTime())) {
+    return new Response(
+      JSON.stringify({
+        error: "Invalid timestamp. Expected an ISO 8601 string.",
+      }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json", ...corsHeaders },
+      },
+    );
+  }
+
+  const result = getStatus(date);
+
+  return new Response(JSON.stringify(result), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+  });
+};

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("GET /api/hours", () => {
+  test("returns all 12 months of hours data", async ({ request }) => {
+    const response = await request.get("/api/hours");
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()["content-type"]).toContain("application/json");
+    expect(response.headers()["access-control-allow-origin"]).toBe("*");
+
+    const data = await response.json();
+    expect(data.hours).toBeDefined();
+
+    const months = Object.keys(data.hours);
+    expect(months).toHaveLength(12);
+    expect(months).toContain("january");
+    expect(months).toContain("december");
+
+    // Each month has open and close times
+    for (const month of months) {
+      expect(data.hours[month].open).toMatch(/^\d{2}:\d{2}$/);
+      expect(data.hours[month].close).toMatch(/^\d{2}:\d{2}$/);
+    }
+  });
+});
+
+test.describe("POST /api/status", () => {
+  test("returns open status for midday in summer", async ({ request }) => {
+    const response = await request.post("/api/status", {
+      data: { timestamp: "2025-07-15T12:00:00+02:00" },
+    });
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()["access-control-allow-origin"]).toBe("*");
+
+    const data = await response.json();
+    expect(data.status).toBe("open");
+    expect(data.closes_at).toBe("23:00");
+    expect(data.time_remaining).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+
+  test("returns closed status for early morning", async ({ request }) => {
+    const response = await request.post("/api/status", {
+      data: { timestamp: "2025-01-15T04:00:00+01:00" },
+    });
+
+    const data = await response.json();
+    expect(data.status).toBe("closed");
+    expect(data.opens_at).toBe("07:30");
+    expect(data.time_remaining).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+
+  test("returns 400 for missing timestamp", async ({ request }) => {
+    const response = await request.post("/api/status", {
+      data: {},
+    });
+
+    expect(response.status()).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBeDefined();
+  });
+
+  test("returns 400 for invalid timestamp", async ({ request }) => {
+    const response = await request.post("/api/status", {
+      data: { timestamp: "not-a-date" },
+    });
+
+    expect(response.status()).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBeDefined();
+  });
+
+  test("returns 400 for invalid JSON", async ({ request }) => {
+    const response = await request.fetch("/api/status", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: "not json{",
+    });
+
+    expect(response.status()).toBe(400);
+  });
+
+  test("includes CORS headers on POST response", async ({ request }) => {
+    const response = await request.post("/api/status", {
+      data: { timestamp: "2025-07-15T12:00:00+02:00" },
+    });
+
+    expect(response.headers()["access-control-allow-origin"]).toBe("*");
+  });
+});


### PR DESCRIPTION
## Summary

- Extract hardcoded hours data from `Interface.astro` into shared `src/data/hours.ts` module
- Add `GET /api/hours` endpoint returning the full 12-month hours table as JSON
- Add `POST /api/status` endpoint accepting a timestamp and returning open/closed status, closing/opening time, and time remaining
- Both endpoints include CORS headers and run server-side on Cloudflare Workers
- Add 7 Playwright tests covering both endpoints, error handling, and CORS
- Update README with API documentation

Closes #14

## Test plan

- [x] `vp check` passes (formatting, linting, types)
- [x] `vp run build` succeeds with API routes as server-side endpoints
- [x] All 10 Playwright tests pass (3 existing smoke + 7 new API tests)
- [ ] Verify `GET /api/hours` returns all 12 months after deploy
- [ ] Verify `POST /api/status` returns correct open/closed for known timestamps after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)