### PR TITLE
Add multilingual support (EN/DE)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,4 +6,11 @@ import cloudflare from "@astrojs/cloudflare";
 // https://astro.build/config
 export default defineConfig({
   adapter: cloudflare(),
+  i18n: {
+    defaultLocale: "en",
+    locales: ["en", "de"],
+    routing: {
+      prefixDefaultLocale: false,
+    },
+  },
 });

--- a/src/components/Interface.astro
+++ b/src/components/Interface.astro
@@ -1,4 +1,12 @@
 ---
+import type { Translations } from "../i18n";
+
+interface Props {
+  t: Translations;
+}
+
+const { t } = Astro.props;
+
 // Tempelhof Feld opening hours
 // Source: https://tempelhofer-feld.berlin.de
 // Last verified: 2026-04-03
@@ -21,9 +29,16 @@ const HOURS: Record<
 };
 ---
 
-<div class="interface" data-hours={JSON.stringify(HOURS)}>
-  <h1 class="title">Is Tempelhof Feld open?</h1>
-  <p class="status" role="status" aria-live="polite">Loading…</p>
+<div
+  class="interface"
+  data-hours={JSON.stringify(HOURS)}
+  data-t-open={t.open}
+  data-t-closed={t.closed}
+  data-t-opens-in={t.opensIn}
+  data-t-closes-in={t.closesIn}
+>
+  <h1 class="title">{t.title}</h1>
+  <p class="status" role="status" aria-live="polite">{t.loading}</p>
   <p class="countdown-label"></p>
   <time class="countdown" datetime=""></time>
 </div>
@@ -34,6 +49,11 @@ const HOURS: Record<
   const countdownLabel = el.querySelector(".countdown-label") as HTMLElement;
   const countdownEl = el.querySelector(".countdown") as HTMLTimeElement;
   const hours = JSON.parse(el.dataset.hours!);
+
+  const tOpen = el.dataset.tOpen!;
+  const tClosed = el.dataset.tClosed!;
+  const tOpensIn = el.dataset.tOpensIn!;
+  const tClosesIn = el.dataset.tClosesIn!;
 
   function getCloseTime(entry: any, day: number): string {
     if (entry.splitDay && day >= entry.splitDay && entry.lateClose) {
@@ -63,7 +83,9 @@ const HOURS: Record<
     const target = new Date(now);
 
     if (isOpen) {
-      const [h, m] = getCloseTime(entry, now.getDate()).split(":").map(Number);
+      const [h, m] = getCloseTime(entry, now.getDate())
+        .split(":")
+        .map(Number);
       target.setHours(h, m, 0, 0);
       return target;
     }
@@ -106,13 +128,13 @@ const HOURS: Record<
     const status = isOpen ? "open" : "closed";
 
     document.documentElement.setAttribute("data-status", status);
-    statusEl.textContent = isOpen ? "Open" : "Closed";
+    statusEl.textContent = isOpen ? tOpen : tClosed;
 
     const target = getTargetTime(now, isOpen);
     const remaining = target.getTime() - now.getTime();
     const { display, iso } = formatDuration(remaining);
 
-    countdownLabel.textContent = isOpen ? "Closes in" : "Opens in";
+    countdownLabel.textContent = isOpen ? tClosesIn : tOpensIn;
     countdownEl.textContent = display;
     countdownEl.setAttribute("datetime", iso);
   }

--- a/src/components/LanguageToggle.astro
+++ b/src/components/LanguageToggle.astro
@@ -1,0 +1,52 @@
+---
+import { getRelativeLocaleUrl } from "astro:i18n";
+import { getTranslations } from "../i18n";
+
+const locale = Astro.currentLocale ?? "en";
+const t = getTranslations(locale);
+const otherLocale = locale === "en" ? "de" : "en";
+const href = getRelativeLocaleUrl(otherLocale, "");
+---
+
+<a class="lang-toggle" href={href} data-other-locale={otherLocale}>
+  {t.langToggle}
+</a>
+
+<script>
+  const toggle = document.querySelector(".lang-toggle") as HTMLAnchorElement;
+  const otherLocale = toggle.dataset.otherLocale!;
+
+  toggle.addEventListener("click", () => {
+    localStorage.setItem("preferred-locale", otherLocale);
+  });
+
+  // Redirect to preferred locale on first visit
+  const preferred = localStorage.getItem("preferred-locale");
+  const current = document.documentElement.lang;
+  if (preferred && preferred !== current) {
+    const target =
+      preferred === "en" ? "/" : `/${preferred}/`;
+    window.location.replace(target);
+  }
+</script>
+
+<style>
+  .lang-toggle {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    color: var(--color-text);
+    text-decoration: none;
+    font-size: 0.875rem;
+    opacity: 0.7;
+    transition: opacity 0.2s ease;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid currentColor;
+    border-radius: 0.25rem;
+  }
+
+  .lang-toggle:hover,
+  .lang-toggle:focus-visible {
+    opacity: 1;
+  }
+</style>

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -1,0 +1,9 @@
+export default {
+  title: "Ist das Tempelhofer Feld ge\u00f6ffnet?",
+  open: "Ge\u00f6ffnet",
+  closed: "Geschlossen",
+  opensIn: "\u00d6ffnet in",
+  closesIn: "Schlie\u00dft in",
+  loading: "Laden\u2026",
+  langToggle: "English",
+} as const;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,0 +1,9 @@
+export default {
+  title: "Is Tempelhof Feld open?",
+  open: "Open",
+  closed: "Closed",
+  opensIn: "Opens in",
+  closesIn: "Closes in",
+  loading: "Loading\u2026",
+  langToggle: "Deutsch",
+} as const;

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,10 @@
+import en from "./en";
+import de from "./de";
+
+export type Translations = Record<keyof typeof en, string>;
+
+const locales: Record<string, Translations> = { en, de };
+
+export function getTranslations(locale: string | undefined): Translations {
+  return locales[locale ?? "en"] ?? en;
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,0 +1,54 @@
+---
+interface Props {
+  title: string;
+  lang: string;
+}
+
+const { title, lang } = Astro.props;
+---
+
+<html lang={lang}>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="generator" content={Astro.generator} />
+    <title>{title}</title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
+
+<style is:global>
+  :root {
+    --color-bg: #2c5f2d;
+    --color-text: #f0f7f0;
+    --color-accent: #ffffff;
+  }
+
+  :root[data-status="closed"] {
+    --color-bg: #1a1a2e;
+    --color-text: #d0d0d8;
+    --color-accent: #e8a0a0;
+  }
+
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  html {
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font-family:
+      system-ui,
+      -apple-system,
+      sans-serif;
+    transition:
+      background-color 0.5s ease,
+      color 0.5s ease;
+  }
+</style>

--- a/src/pages/de/index.astro
+++ b/src/pages/de/index.astro
@@ -1,0 +1,13 @@
+---
+import Base from "../../layouts/Base.astro";
+import Interface from "../../components/Interface.astro";
+import LanguageToggle from "../../components/LanguageToggle.astro";
+import { getTranslations } from "../../i18n";
+
+const t = getTranslations(Astro.currentLocale);
+---
+
+<Base title={t.title} lang="de">
+  <LanguageToggle />
+  <Interface t={t} />
+</Base>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,49 +1,13 @@
 ---
+import Base from "../layouts/Base.astro";
 import Interface from "../components/Interface.astro";
+import LanguageToggle from "../components/LanguageToggle.astro";
+import { getTranslations } from "../i18n";
+
+const t = getTranslations(Astro.currentLocale);
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width" />
-    <meta name="generator" content={Astro.generator} />
-    <title>Is Tempelhof Feld open?</title>
-  </head>
-  <body>
-    <Interface />
-  </body>
-</html>
-
-<style is:global>
-  :root {
-    --color-bg: #2c5f2d;
-    --color-text: #f0f7f0;
-    --color-accent: #ffffff;
-  }
-
-  :root[data-status="closed"] {
-    --color-bg: #1a1a2e;
-    --color-text: #d0d0d8;
-    --color-accent: #e8a0a0;
-  }
-
-  * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-
-  html {
-    background-color: var(--color-bg);
-    color: var(--color-text);
-    font-family:
-      system-ui,
-      -apple-system,
-      sans-serif;
-    transition:
-      background-color 0.5s ease,
-      color 0.5s ease;
-  }
-</style>
+<Base title={t.title} lang="en">
+  <LanguageToggle />
+  <Interface t={t} />
+</Base>

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -31,3 +31,32 @@ test("countdown timer is visible and updating", async ({ page }) => {
   expect(second).toMatch(/\d+h \d{2}m \d{2}s/);
   expect(second).not.toBe(first);
 });
+
+test("German page loads with translated title and status", async ({ page }) => {
+  await page.goto("/de/");
+
+  await expect(page).toHaveTitle("Ist das Tempelhofer Feld geöffnet?");
+  await expect(
+    page.getByRole("heading", {
+      name: "Ist das Tempelhofer Feld geöffnet?",
+    }),
+  ).toBeVisible();
+
+  const status = page.locator(".status");
+  await expect(status).toHaveText(/^(Geöffnet|Geschlossen)$/);
+});
+
+test("language toggle is visible and links to other locale", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const toggle = page.locator(".lang-toggle");
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveText("Deutsch");
+  await expect(toggle).toHaveAttribute("href", "/de/");
+
+  await page.goto("/de/");
+  await expect(toggle).toHaveText("English");
+  await expect(toggle).toHaveAttribute("href", "/");
+});


### PR DESCRIPTION
## Summary
- Configure Astro i18n routing with English (`/`) and German (`/de/`) locales
- Extract all UI strings into typed locale files (`src/i18n/en.ts`, `src/i18n/de.ts`)
- Add accessible language toggle with localStorage preference persistence
- Extract shared `Base` layout to eliminate page duplication
- Add Playwright tests for German page and language switcher

## Test plan
- [x] `vp check` passes (format, lint, types)
- [x] All 5 Playwright tests pass (3 existing + 2 new)
- [ ] Manually verify `/` shows English UI
- [ ] Manually verify `/de/` shows German UI
- [ ] Verify language toggle navigates between locales
- [ ] Verify preferred language is remembered on revisit
- [ ] Review German translations with DeepL for accuracy

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)