### PR TITLE
Dynamic page title and favicon for open/closed status

### DIFF
--- a/src/components/Interface.astro
+++ b/src/components/Interface.astro
@@ -48,6 +48,33 @@ const { t } = Astro.props;
     return { display, iso };
   }
 
+  let faviconLink =
+    (document.querySelector('link[rel="icon"][type="image/svg+xml"]') as HTMLLinkElement) ||
+    (document.querySelector('link[rel="icon"]') as HTMLLinkElement);
+  let lastFaviconStatus: boolean | null = null;
+
+  function updateFavicon(open: boolean) {
+    if (lastFaviconStatus === open) return;
+    lastFaviconStatus = open;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = 32;
+    canvas.height = 32;
+    const ctx = canvas.getContext("2d")!;
+    ctx.beginPath();
+    ctx.arc(16, 16, 14, 0, Math.PI * 2);
+    ctx.fillStyle = open ? "#22c55e" : "#ef4444";
+    ctx.fill();
+
+    if (!faviconLink) {
+      faviconLink = document.createElement("link");
+      faviconLink.rel = "icon";
+      document.head.appendChild(faviconLink);
+    }
+    faviconLink.type = "image/png";
+    faviconLink.href = canvas.toDataURL("image/png");
+  }
+
   function update() {
     const now = new Date();
     const open = isOpen(now);
@@ -60,9 +87,13 @@ const { t } = Astro.props;
     const remaining = target.getTime() - now.getTime();
     const { display, iso } = formatDuration(remaining);
 
-    countdownLabel.textContent = open ? tClosesIn : tOpensIn;
+    const label = open ? tClosesIn : tOpensIn;
+    countdownLabel.textContent = label;
     countdownEl.textContent = display;
     countdownEl.setAttribute("datetime", iso);
+
+    document.title = `${label} ${display} — Tempelhof Feld`;
+    updateFavicon(open);
   }
 
   update();

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test("page loads with title and status", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page).toHaveTitle("Is Tempelhof Feld open?");
+  await expect(page).toHaveTitle(/— Tempelhof Feld$/);
   await expect(
     page.getByRole("heading", { name: "Is Tempelhof Feld open?" }),
   ).toBeVisible();
@@ -35,7 +35,7 @@ test("countdown timer is visible and updating", async ({ page }) => {
 test("German page loads with translated title and status", async ({ page }) => {
   await page.goto("/de/");
 
-  await expect(page).toHaveTitle("Ist das Tempelhofer Feld geöffnet?");
+  await expect(page).toHaveTitle(/— Tempelhof Feld$/);
   await expect(
     page.getByRole("heading", {
       name: "Ist das Tempelhofer Feld geöffnet?",


### PR DESCRIPTION
## Summary
- Page title updates every second: `"Closes in 2h 34m 12s — Tempelhof Feld"` (open) / `"Opens in 2h 34m 12s — Tempelhof Feld"` (closed)
- Favicon dynamically generated via canvas: green dot when open, red dot when closed
- Favicon only redraws when status changes (not every tick)

Closes #23

## Test plan
- [x] `vp check` passes
- [x] All 3 Playwright smoke tests pass (title test updated to match dynamic format)
- [ ] Verify title ticks in browser tab
- [ ] Verify favicon changes color based on status

🤖 Generated with [Claude Code](https://claude.com/claude-code)