### PR TITLE
Auto-translate i18n files via DeepL on PRs

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,0 +1,71 @@
+name: Auto-translate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/i18n/en.ts"
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          cache: true
+
+      - name: Translate changed keys
+        id: translate
+        env:
+          DEEPL_API_KEY: ${{ secrets.DEEPL_API_KEY }}
+        run: |
+          npx tsx scripts/translate.ts | tee /tmp/translate-output.txt
+          if git diff --quiet src/i18n/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Format translated files
+        if: steps.translate.outputs.changed == 'true'
+        run: vp fmt src/i18n/
+
+      - name: Commit translations
+        if: steps.translate.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/i18n/
+          git commit -m "Auto-translate i18n keys via DeepL"
+          git push
+
+      - name: Build PR comment
+        if: steps.translate.outputs.changed == 'true'
+        id: summary
+        run: |
+          CHANGED_FILES=$(git diff HEAD~1 --name-only | grep '^src/i18n/' | grep -v 'en.ts' || true)
+          FILE_LIST=$(echo "$CHANGED_FILES" | sed 's/^/- `/' | sed 's/$/`/')
+          BODY=$(printf '🌐 Auto-translated i18n keys via DeepL\n\nUpdated files:\n%s' "$FILE_LIST")
+          echo "body<<EOFCOMMENT" >> "$GITHUB_OUTPUT"
+          echo "$BODY" >> "$GITHUB_OUTPUT"
+          echo "EOFCOMMENT" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        if: steps.translate.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `${{ steps.summary.outputs.body }}`,
+            });

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -52,20 +52,27 @@ jobs:
         id: summary
         run: |
           CHANGED_FILES=$(git diff HEAD~1 --name-only | grep '^src/i18n/' | grep -v 'en.ts' || true)
-          FILE_LIST=$(echo "$CHANGED_FILES" | sed 's/^/- `/' | sed 's/$/`/')
-          BODY=$(printf '🌐 Auto-translated i18n keys via DeepL\n\nUpdated files:\n%s' "$FILE_LIST")
-          echo "body<<EOFCOMMENT" >> "$GITHUB_OUTPUT"
-          echo "$BODY" >> "$GITHUB_OUTPUT"
-          echo "EOFCOMMENT" >> "$GITHUB_OUTPUT"
+          FILE_LIST=$(echo "$CHANGED_FILES" | sed 's/^/- /' | sed 's/$/ /')
+          {
+            echo "body<<EOFCOMMENT"
+            echo "Auto-translated i18n keys via DeepL"
+            echo ""
+            echo "Updated files:"
+            echo "$FILE_LIST"
+            echo "EOFCOMMENT"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR
         if: steps.translate.outputs.changed == 'true'
         uses: actions/github-script@v7
         with:
           script: |
+            const body = process.env.COMMENT_BODY;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `${{ steps.summary.outputs.body }}`,
+              body,
             });
+        env:
+          COMMENT_BODY: ${{ steps.summary.outputs.body }}

--- a/scripts/translate.test.ts
+++ b/scripts/translate.test.ts
@@ -1,0 +1,277 @@
+import { describe, test, expect, vi } from "vite-plus/test";
+import {
+  parseTranslationFile,
+  generateTranslationFile,
+  detectChanges,
+  translateTexts,
+  translateDiff,
+} from "./translate.js";
+
+// --- parseTranslationFile ---
+
+describe("parseTranslationFile", () => {
+  test("parses a standard translation file", () => {
+    const content = `export default {
+  title: "Hello",
+  open: "Open",
+  closed: "Closed",
+} as const;`;
+    expect(parseTranslationFile(content)).toEqual({
+      title: "Hello",
+      open: "Open",
+      closed: "Closed",
+    });
+  });
+
+  test("handles escaped characters", () => {
+    const content = `export default {
+  title: "Ist das Tempelhofer Feld ge\\u00f6ffnet?",
+} as const;`;
+    expect(parseTranslationFile(content)).toEqual({
+      title: "Ist das Tempelhofer Feld ge\\u00f6ffnet?",
+    });
+  });
+
+  test("returns empty object for empty file", () => {
+    expect(parseTranslationFile("export default {} as const;\n")).toEqual({});
+  });
+});
+
+// --- generateTranslationFile ---
+
+describe("generateTranslationFile", () => {
+  test("generates correct file format", () => {
+    const translations = { title: "Hello", open: "Open" };
+    const result = generateTranslationFile(translations, ["title", "open"]);
+    expect(result).toBe(
+      `export default {\n  title: "Hello",\n  open: "Open",\n} as const;\n`,
+    );
+  });
+
+  test("respects key order", () => {
+    const translations = { b: "B", a: "A", c: "C" };
+    const result = generateTranslationFile(translations, ["c", "a", "b"]);
+    expect(result).toContain('  c: "C",\n  a: "A",\n  b: "B",');
+  });
+
+  test("omits keys not in translations", () => {
+    const translations = { a: "A" };
+    const result = generateTranslationFile(translations, ["a", "b"]);
+    expect(result).not.toContain("b:");
+  });
+
+  test("escapes double quotes in values", () => {
+    const translations = { title: 'Say "hello"' };
+    const result = generateTranslationFile(translations, ["title"]);
+    expect(result).toContain('title: "Say \\"hello\\"",');
+  });
+});
+
+// --- detectChanges ---
+
+describe("detectChanges", () => {
+  test("detects added keys", () => {
+    const old = { a: "A" };
+    const next = { a: "A", b: "B" };
+    expect(detectChanges(old, next)).toEqual({
+      added: ["b"],
+      changed: [],
+      removed: [],
+    });
+  });
+
+  test("detects changed keys", () => {
+    const old = { a: "A" };
+    const next = { a: "A updated" };
+    expect(detectChanges(old, next)).toEqual({
+      added: [],
+      changed: ["a"],
+      removed: [],
+    });
+  });
+
+  test("detects removed keys", () => {
+    const old = { a: "A", b: "B" };
+    const next = { a: "A" };
+    expect(detectChanges(old, next)).toEqual({
+      added: [],
+      changed: [],
+      removed: ["b"],
+    });
+  });
+
+  test("handles all change types at once", () => {
+    const old = { a: "A", b: "B", c: "C" };
+    const next = { a: "A modified", c: "C", d: "D" };
+    const result = detectChanges(old, next);
+    expect(result.added).toEqual(["d"]);
+    expect(result.changed).toEqual(["a"]);
+    expect(result.removed).toEqual(["b"]);
+  });
+
+  test("returns empty arrays when nothing changed", () => {
+    const keys = { a: "A", b: "B" };
+    expect(detectChanges(keys, keys)).toEqual({
+      added: [],
+      changed: [],
+      removed: [],
+    });
+  });
+});
+
+// --- translateDiff (with mocked API) ---
+
+describe("translateDiff", () => {
+  const mockFetch = vi.fn();
+
+  function mockDeepLResponse(texts: string[]) {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        translations: texts.map((text) => ({ text })),
+      }),
+    });
+  }
+
+  test("translates added and changed keys", async () => {
+    vi.stubGlobal("fetch", mockFetch);
+
+    const oldEn = `export default {
+  title: "Hello",
+} as const;`;
+
+    const newEn = `export default {
+  title: "Hello updated",
+  subtitle: "World",
+} as const;`;
+
+    // added keys come first, then changed — so subtitle (added), title (changed)
+    mockDeepLResponse(["Welt", "Hallo aktualisiert"]);
+
+    const results = await translateDiff({
+      oldEnContent: oldEn,
+      newEnContent: newEn,
+      targetLanguages: ["DE"],
+      apiKey: "fake-key",
+      i18nDir: "/tmp/fake",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].translated).toEqual(["subtitle", "title"]);
+    expect(results[0].content).toContain('title: "Hallo aktualisiert"');
+    expect(results[0].content).toContain('subtitle: "Welt"');
+
+    vi.unstubAllGlobals();
+  });
+
+  test("removes deleted keys from target", async () => {
+    vi.stubGlobal("fetch", mockFetch);
+
+    const oldEn = `export default {
+  title: "Hello",
+  old: "Remove me",
+} as const;`;
+
+    const newEn = `export default {
+  title: "Hello",
+} as const;`;
+
+    const results = await translateDiff({
+      oldEnContent: oldEn,
+      newEnContent: newEn,
+      targetLanguages: ["DE"],
+      apiKey: "fake-key",
+      i18nDir: "/tmp/fake",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].removed).toEqual(["old"]);
+    expect(results[0].content).not.toContain("old:");
+
+    vi.unstubAllGlobals();
+  });
+
+  test("returns empty array when nothing changed", async () => {
+    const content = `export default {
+  title: "Hello",
+} as const;`;
+
+    const results = await translateDiff({
+      oldEnContent: content,
+      newEnContent: content,
+      targetLanguages: ["DE"],
+      apiKey: "fake-key",
+      i18nDir: "/tmp/fake",
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  test("translates to multiple languages", async () => {
+    vi.stubGlobal("fetch", mockFetch);
+
+    const oldEn = `export default {} as const;`;
+    const newEn = `export default {
+  title: "Hello",
+} as const;`;
+
+    mockDeepLResponse(["Hallo"]);
+    mockDeepLResponse(["Bonjour"]);
+
+    const results = await translateDiff({
+      oldEnContent: oldEn,
+      newEnContent: newEn,
+      targetLanguages: ["DE", "FR"],
+      apiKey: "fake-key",
+      i18nDir: "/tmp/fake",
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0].content).toContain("Hallo");
+    expect(results[1].content).toContain("Bonjour");
+
+    vi.unstubAllGlobals();
+  });
+
+  test("preserves key order from en.ts", async () => {
+    vi.stubGlobal("fetch", mockFetch);
+
+    const oldEn = `export default {} as const;`;
+    const newEn = `export default {
+  zebra: "Z",
+  alpha: "A",
+  middle: "M",
+} as const;`;
+
+    mockDeepLResponse(["Z-de", "A-de", "M-de"]);
+
+    const results = await translateDiff({
+      oldEnContent: oldEn,
+      newEnContent: newEn,
+      targetLanguages: ["DE"],
+      apiKey: "fake-key",
+      i18nDir: "/tmp/fake",
+    });
+
+    const lines = results[0].content.split("\n");
+    const keyLines = lines.filter((l) => l.includes(":"));
+    expect(keyLines[0]).toContain("zebra");
+    expect(keyLines[1]).toContain("alpha");
+    expect(keyLines[2]).toContain("middle");
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// --- Integration test with real DeepL API ---
+
+describe("DeepL API integration", () => {
+  const apiKey = process.env.DEEPL_API_KEY;
+
+  test.skipIf(!apiKey)("translates a string to German", async () => {
+    const results = await translateTexts(["Hello"], "DE", apiKey!);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toBeTruthy();
+    expect(results[0].toLowerCase()).toContain("hallo");
+  });
+});

--- a/scripts/translate.ts
+++ b/scripts/translate.ts
@@ -1,0 +1,265 @@
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const I18N_DIR = resolve(__dirname, "../src/i18n");
+
+// Add target languages here to auto-translate
+const TARGET_LANGUAGES = ["DE"];
+
+const DEEPL_API_URL = "https://api-free.deepl.com/v2/translate";
+
+// --- Parsing and generation ---
+
+export function parseTranslationFile(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const regex = /(\w+):\s*"((?:[^"\\]|\\.)*)"/g;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    result[match[1]] = match[2].replace(/\\"/g, '"');
+  }
+  return result;
+}
+
+export function generateTranslationFile(
+  translations: Record<string, string>,
+  keyOrder: string[],
+): string {
+  const lines = keyOrder
+    .filter((key) => key in translations)
+    .map((key) => {
+      const value = translations[key].replace(/"/g, '\\"');
+      return `  ${key}: "${value}",`;
+    });
+  return `export default {\n${lines.join("\n")}\n} as const;\n`;
+}
+
+// --- Diff detection ---
+
+export function detectChanges(
+  oldKeys: Record<string, string>,
+  newKeys: Record<string, string>,
+): { added: string[]; changed: string[]; removed: string[] } {
+  const added: string[] = [];
+  const changed: string[] = [];
+  const removed: string[] = [];
+
+  for (const key of Object.keys(newKeys)) {
+    if (!(key in oldKeys)) {
+      added.push(key);
+    } else if (oldKeys[key] !== newKeys[key]) {
+      changed.push(key);
+    }
+  }
+
+  for (const key of Object.keys(oldKeys)) {
+    if (!(key in newKeys)) {
+      removed.push(key);
+    }
+  }
+
+  return { added, changed, removed };
+}
+
+// --- DeepL API ---
+
+export async function translateTexts(
+  texts: string[],
+  targetLang: string,
+  apiKey: string,
+): Promise<string[]> {
+  if (texts.length === 0) return [];
+
+  const response = await fetch(DEEPL_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `DeepL-Auth-Key ${apiKey}`,
+    },
+    body: JSON.stringify({
+      text: texts,
+      source_lang: "EN",
+      target_lang: targetLang,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`DeepL API error (${response.status}): ${body}`);
+  }
+
+  const data = (await response.json()) as {
+    translations: { text: string }[];
+  };
+  return data.translations.map((t) => t.text);
+}
+
+// --- Main logic ---
+
+export interface TranslateResult {
+  language: string;
+  translated: string[];
+  removed: string[];
+  filePath: string;
+  content: string;
+}
+
+export async function translateDiff(options: {
+  oldEnContent: string;
+  newEnContent: string;
+  targetLanguages: string[];
+  apiKey: string;
+  i18nDir: string;
+  langToggleValues?: Record<string, string>;
+}): Promise<TranslateResult[]> {
+  const { oldEnContent, newEnContent, targetLanguages, apiKey, i18nDir } =
+    options;
+
+  const oldKeys = parseTranslationFile(oldEnContent);
+  const newKeys = parseTranslationFile(newEnContent);
+  const { added, changed, removed } = detectChanges(oldKeys, newKeys);
+  const keysToTranslate = [...added, ...changed];
+
+  if (keysToTranslate.length === 0 && removed.length === 0) {
+    return [];
+  }
+
+  const newKeyOrder = Object.keys(newKeys);
+  const results: TranslateResult[] = [];
+
+  for (const lang of targetLanguages) {
+    const langCode = lang.toLowerCase();
+    const filePath = resolve(i18nDir, `${langCode}.ts`);
+
+    // Load existing translations or start fresh
+    let existing: Record<string, string> = {};
+    if (existsSync(filePath)) {
+      existing = parseTranslationFile(readFileSync(filePath, "utf-8"));
+    }
+
+    // Remove deleted keys
+    for (const key of removed) {
+      delete existing[key];
+    }
+
+    // Translate changed/added keys (skip langToggle — it's not translatable)
+    const textsToTranslate = keysToTranslate
+      .filter((k) => k !== "langToggle")
+      .map((k) => newKeys[k]);
+    const keysForApi = keysToTranslate.filter((k) => k !== "langToggle");
+
+    if (textsToTranslate.length > 0) {
+      const translated = await translateTexts(textsToTranslate, lang, apiKey);
+      for (let i = 0; i < keysForApi.length; i++) {
+        existing[keysForApi[i]] = translated[i];
+      }
+    }
+
+    // Handle langToggle separately if it was added/changed
+    if (
+      keysToTranslate.includes("langToggle") &&
+      options.langToggleValues?.[langCode]
+    ) {
+      existing["langToggle"] = options.langToggleValues[langCode];
+    }
+
+    const content = generateTranslationFile(existing, newKeyOrder);
+    results.push({
+      language: lang,
+      translated: keysToTranslate,
+      removed,
+      filePath,
+      content,
+    });
+  }
+
+  return results;
+}
+
+// --- CLI entry point ---
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const apiKey = process.env.DEEPL_API_KEY;
+
+  if (!apiKey) {
+    console.error("DEEPL_API_KEY environment variable is required");
+    process.exit(1);
+  }
+
+  // Read current en.ts
+  const newEnPath = resolve(I18N_DIR, "en.ts");
+  const newEnContent = readFileSync(newEnPath, "utf-8");
+
+  // Read base en.ts from main branch
+  let oldEnContent: string;
+  try {
+    const { execSync } = await import("node:child_process");
+    oldEnContent = execSync("git show origin/main:src/i18n/en.ts", {
+      encoding: "utf-8",
+    });
+  } catch {
+    console.log("No base en.ts found on main — treating all keys as new");
+    oldEnContent = "export default {} as const;\n";
+  }
+
+  const results = await translateDiff({
+    oldEnContent,
+    newEnContent,
+    targetLanguages: TARGET_LANGUAGES,
+    apiKey,
+    i18nDir: I18N_DIR,
+  });
+
+  if (results.length === 0) {
+    console.log("No translation changes needed");
+    process.exit(0);
+  }
+
+  for (const result of results) {
+    if (dryRun) {
+      console.log(`\n[DRY RUN] Would update ${result.language}:`);
+      if (result.translated.length > 0) {
+        console.log(`  Translate: ${result.translated.join(", ")}`);
+      }
+      if (result.removed.length > 0) {
+        console.log(`  Remove: ${result.removed.join(", ")}`);
+      }
+      console.log(`\n${result.content}`);
+    } else {
+      writeFileSync(result.filePath, result.content);
+      console.log(`Updated ${result.filePath}`);
+    }
+  }
+
+  // Output summary for GitHub Actions
+  if (!dryRun) {
+    const summary = results
+      .map((r) => {
+        const items = r.translated.map((k) => `- \`${k}\``).join("\n");
+        const removedItems =
+          r.removed.length > 0
+            ? `\nRemoved:\n${r.removed.map((k) => `- \`${k}\``).join("\n")}`
+            : "";
+        return `🌐 Auto-translated ${r.translated.length} key(s) to ${r.language} via DeepL:\n${items}${removedItems}`;
+      })
+      .join("\n\n");
+    console.log(
+      `\n::set-output name=summary::${summary.replace(/\n/g, "%0A")}`,
+    );
+  }
+}
+
+// Only run main when executed directly
+const isDirectRun =
+  process.argv[1] &&
+  (process.argv[1].endsWith("translate.ts") ||
+    process.argv[1].endsWith("translate.mjs"));
+
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -6,4 +6,5 @@ export default {
   closesIn: "Schlie\u00dft in",
   loading: "Laden\u2026",
   langToggle: "English",
+  info: "Weitere Informationen",
 } as const;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -6,4 +6,5 @@ export default {
   closesIn: "Closes in",
   loading: "Loading\u2026",
   langToggle: "Deutsch",
+  info: "More information",
 } as const;


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/translate.yml` — triggers on PRs when `src/i18n/en.ts` changes
- Adds `scripts/translate.ts` — detects changed/added/removed keys, translates via DeepL Free API, writes updated language files
- Only sends diff to DeepL (preserves existing manual translations for unchanged keys)
- Commits translations back to the PR branch and posts a summary comment
- Supports `--dry-run` flag for testing without side effects
- Designed for multiple target languages (currently `["DE"]`, extend the list to add more)

Closes #27

## Testing
- [x] `vp check` passes
- [x] `vp test` — 17 unit tests pass, 1 integration test skipped (no `DEEPL_API_KEY`)
- Unit tests cover: file parsing, file generation, diff detection, mocked translation, multi-language, key ordering, key removal
- [ ] Add `DEEPL_API_KEY` as a repo secret for the workflow to function

## Secrets required
- `DEEPL_API_KEY` — DeepL Free API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)