### PR TITLE
Fix deploy action: add pnpm setup for wrangler

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: pnpm/action-setup@v4
+
       - uses: voidzero-dev/setup-vp@v1
         with:
           cache: true


### PR DESCRIPTION
## Summary
- The `cloudflare/wrangler-action@v3` deploy step fails with `"Unable to locate executable file: pnpm"` because `voidzero-dev/setup-vp@v1` doesn't put pnpm on the system PATH
- Adds `pnpm/action-setup@v4` before setup-vp so pnpm is available for the wrangler deploy step (version auto-detected from `packageManager` in package.json)

## Test plan
- [ ] Verify the Deploy workflow passes on push to main

https://claude.ai/code/session_01W6CDHFcCZHVTF2cy3Fd84g